### PR TITLE
Deploy Javadoc to Github Pages

### DIFF
--- a/.github/workflows/ci-cd.yaml
+++ b/.github/workflows/ci-cd.yaml
@@ -1,0 +1,57 @@
+# Copyright Jiaqi Liu
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: CI/CD
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - master
+
+env:
+  JDK_VERSION: 17
+  JDK_DISTRIBUTION: 'adopt'
+  USER: QubitPi
+  EMAIL: jack20220723@gmail.com
+
+jobs:
+  documentation:
+    name: Publish Javadoc to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK ${{ env.JDK_VERSION }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ env.JDK_VERSION }}
+          distribution: ${{ env.JDK_DISTRIBUTION }}
+      - name: Generate Javadoc
+        run: |
+          cd shaded
+          mvn clean package
+          cd ../
+          mvn package
+          mvn javadoc:aggregate -Pjavadoc
+      - name: Load CNAME
+        run: echo arango-java.qubitpi.org > ./target/reports/apidocs/CNAME
+      - name: Deploy Javadoc to GitHub Pages
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/reports/apidocs
+          enable_jekyll: false
+          user_name: ${{ env.USER }}
+          user_email: ${{ env.EMAIL }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ test-results-native
 
 dependency-reduced-pom.xml
 /bin/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,15 +1,1 @@
-![ArangoDB-Logo](https://user-images.githubusercontent.com/3998723/207981337-79d49127-48fc-4c7c-9411-8a688edca1dd.png)
-
-# ArangoDB Java Driver
-
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.arangodb/arangodb-java-driver/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.arangodb/arangodb-java-driver)
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/arangodb/arangodb-java-driver/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/arangodb/arangodb-java-driver/tree/main)
-
-The official [ArangoDB](https://www.arangodb.com/) Java Driver.
-
-## Learn more
-
-- [ChangeLog](ChangeLog.md)
-- [Examples](test-non-functional/src/test/java/example)
-- [Documentation and Tutorial](https://docs.arangodb.com/stable/develop/drivers/java/)
-- [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html)
+tutorial/Tutorial.md

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     </licenses>
 
     <properties>
+        <doclint>none</doclint>
         <maven.compiler.target>8</maven.compiler.target>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.release>8</maven.compiler.release>

--- a/tutorial/Tutorial.md
+++ b/tutorial/Tutorial.md
@@ -1,12 +1,20 @@
+![](https://github.com/QubitPi/QubitPi/blob/master/img/arango-logo-with-text.png?raw=true)
+
 # ArangoDB Java driver
+
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/arangodb/arangodb-java-driver/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/arangodb/arangodb-java-driver/tree/main)
+
+[![Maven Central](https://img.shields.io/maven-central/v/com.arangodb/arangodb-java-driver?style=for-the-badge&logo=apachemaven&logoColor=white&labelColor=4D9FEA&color=brightgreen)](https://maven-badges.herokuapp.com/maven-central/com.arangodb/arangodb-java-driver)
+[![GitHub workflow status badge][GitHub workflow status badge]][GitHub workflow status URL]
+[![Apache License][Apache License Badge]][Apache License, Version 2.0]
 
 The official ArangoDB Java Driver.
 
-- Repository: <https://github.com/arangodb/arangodb-java-driver>
-- [Code examples](https://github.com/arangodb/arangodb-java-driver/tree/main/test-non-functional/src/test/java/example)
+- Repository: <https://github.com/QubitPi/arangodb-java-driver>
+- [Code examples](https://github.com/QubitPi/arangodb-java-driver/tree/main/test-non-functional/src/test/java/example)
 - [Reference](reference-version-7/_index.md) (driver setup, serialization, changes in version 7)
-- [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html) (generated reference documentation)
-- [ChangeLog](https://github.com/arangodb/arangodb-java-driver/blob/main/ChangeLog.md)
+- [JavaDoc] (generated reference documentation)
+- [ChangeLog](https://github.com/QubitPi/arangodb-java-driver/blob/main/ChangeLog.md)
 
 ## Supported versions
 
@@ -339,8 +347,7 @@ Removed document: 6
   query language
 - See [Serialization](reference-version-7/serialization.md) for details about
   user-data serde
-- For the full reference documentation, see
-  [JavaDoc](https://www.javadoc.io/doc/com.arangodb/arangodb-java-driver/latest/index.html)
+- For the full reference documentation, see [JavaDoc]
 
 ## GraalVM Native Image
 
@@ -348,7 +355,7 @@ The driver supports GraalVM Native Image compilation.
 To compile with `--link-at-build-time` when `http-protocol` module is present in
 the classpath, additional substitutions are required for transitive dependencies
 `Netty` and `Vert.x`. See this
-[example](https://github.com/arangodb/arangodb-java-driver/tree/main/test-functional/src/test-default/java/graal)
+[example](https://github.com/QubitPi/arangodb-java-driver/tree/main/test-functional/src/test-default/java/graal)
 for reference. Such substitutions are not required when compiling the shaded driver.
 
 ### Framework compatibility
@@ -472,3 +479,11 @@ and deserialized internally by the driver.
 The behavior to serialize and deserialize these classes is considered an internal
 implementation detail, and as such, it might change without prior notice.
 The API with regard to the public members of these classes is kept compatible.
+
+[Apache License, Version 2.0]: https://www.apache.org/licenses/LICENSE-2.0
+[Apache License Badge]: https://img.shields.io/badge/Apache%202.0-F25910.svg?style=for-the-badge&logo=Apache&logoColor=white
+
+[GitHub workflow status badge]: https://img.shields.io/github/actions/workflow/status/QubitPi/arangodb-java-driver/ci-cd.yaml?branch=master&style=for-the-badge&logo=github&logoColor=white&label=CI/CD
+[GitHub workflow status URL]: https://github.com/QubitPi/arangodb-java-driver/actions/workflows/ci-cd.yaml
+
+[JavaDoc]: https://arango-java.qubitpi.org/


### PR DESCRIPTION
Reference - https://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html